### PR TITLE
fix: add a failing test to showing a bug with returning a string from a jsonrpc request handler

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -563,13 +563,7 @@ describe('FlowExecutor', () => {
     };
     const executor = new FlowExecutor(flow, mockJsonRpcHandler, noLogger);
     const results = await executor.execute();
-    expect(results.get('step1').result).toEqual({
-      items: [
-        { id: 1, name: 'Item 1', value: 100 },
-        { id: 2, name: 'Item 2', value: 200 },
-        { id: 3, name: 'Item 3', value: 300 },
-      ],
-    });
+    expect(results.get('step1').result).toEqual('foo');
     expect(results.get('step2').result).toEqual({
       item: 'foo foo',
     });


### PR DESCRIPTION
looks like the offending code is here:

https://github.com/BelfordZ/open-rpc-flow/blob/9641053fb0df6c90948d03c835b2bbca8d916061/src/step-executors/request-executor.ts#L67-L80

i tried to try catcn here some other things started failing