### PR TITLE
fix: improved typing on flow error and arrays

### DIFF
--- a/src/errors/recovery.ts
+++ b/src/errors/recovery.ts
@@ -26,7 +26,7 @@ export interface RetryPolicy {
  */
 export class RetryableOperation<T> {
   private logger: Logger;
-  private allErrors: any[] = [];
+  private allErrors: unknown[] = [];
 
   constructor(
     private operation: () => Promise<T>,

--- a/src/step-executors/condition-executor.ts
+++ b/src/step-executors/condition-executor.ts
@@ -4,8 +4,8 @@ import { Logger } from '../util/logger';
 import { ValidationError, ExecutionError } from '../errors/base';
 import { TimeoutError } from '../errors/timeout-error';
 
-class ConditionStepExecutionError extends ExecutionError {
-  constructor(message: string, context: Record<string, any>, cause?: Error) {
+class ConditionStepExecutionError extends ExecutionError<Record<string, unknown>> {
+  constructor(message: string, context: Record<string, unknown>, cause?: Error) {
     super(message, { ...context, code: 'EXECUTION_ERROR' }, cause);
     this.name = 'ConditionStepExecutionError';
     Object.setPrototypeOf(this, ConditionStepExecutionError.prototype);


### PR DESCRIPTION
Summary

Generic context support was added to the base error classes, ensuring context objects are typed with Record<string, unknown> by default

MaxRetriesExceededError now stores its collected errors in an unknown[] array, and stringifies them safely with type casts

The retry logic uses an unknown[] list for tracking errors during retries

Condition step execution errors now extend the generic ExecutionError with a properly typed context