### PR TITLE
Unify StepType enum in API

### DIFF
--- a/src/dependency-resolver/resolver.ts
+++ b/src/dependency-resolver/resolver.ts
@@ -1,4 +1,5 @@
 import { Flow, Step, DependencyGraph, DependencyNode } from '../types';
+import { StepType } from '../step-executors/types';
 import { Logger } from '../util/logger';
 import {
   isLoopStep,
@@ -295,10 +296,10 @@ export class DependencyResolver {
       const dependents = this.getDependents(step.name);
 
       // Determine step type
-      let type: DependencyNode['type'] = 'request'; // default
-      if (isLoopStep(step)) type = 'loop';
-      if (isConditionStep(step)) type = 'condition';
-      if (isTransformStep(step)) type = 'transform';
+      let type: DependencyNode['type'] = StepType.Request; // default
+      if (isLoopStep(step)) type = StepType.Loop;
+      if (isConditionStep(step)) type = StepType.Condition;
+      if (isTransformStep(step)) type = StepType.Transform;
 
       nodes.push({
         name: step.name,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { Flow, Step, JsonRpcRequest } from './types';
+export { StepType } from './step-executors/types';
 export { FlowExecutor, FlowExecutorOptions, DEFAULT_RETRY_POLICY } from './flow-executor';
 export { SafeExpressionEvaluator } from './expression-evaluator/safe-evaluator';
 export {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,10 @@
+import type { StepType } from './step-executors/types';
 import { TransformOperation } from './step-executors/types';
 import { ReferenceResolver } from './reference-resolver';
 import { SafeExpressionEvaluator } from './expression-evaluator/safe-evaluator';
 import { Logger } from './util/logger';
 
-export type StepType = 'request' | 'loop' | 'condition' | 'transform' | 'stop';
+export type { StepType } from './step-executors/types';
 
 /**
  * Policies for a specific step type or as a default for all steps

--- a/src/util/policy-resolver.ts
+++ b/src/util/policy-resolver.ts
@@ -1,4 +1,5 @@
-import { Flow, Step, StepType } from '../types';
+import type { Flow, Step } from '../types';
+import type { StepType } from '../step-executors/types';
 import { Logger, defaultLogger } from '../util/logger';
 import { DEFAULT_TIMEOUTS } from '../constants/timeouts';
 import { DEFAULT_RETRY_POLICY } from '../flow-executor';


### PR DESCRIPTION
## Summary
- remove string union for `StepType`
- re-export enum from `step-executors`
- update imports and tests
- export `StepType` from public index

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`
- `npm test`