### PR TITLE
fix: reuse getStepType

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,10 +14,10 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      branches: 92.31,
-      functions: 96.55,
+      branches: 92.61,
+      functions: 96.56,
       lines: 97.91,
-      statements: 97.69,
+      statements: 97.82,
     },
   },
 };

--- a/src/util/flow-executor-events.ts
+++ b/src/util/flow-executor-events.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'events';
-import { Step, StepExecutionContext } from '../types';
+import { Step, StepExecutionContext, getStepType } from '../types';
 import { StepExecutionResult } from '../step-executors';
 
 /**
@@ -210,7 +210,7 @@ export class FlowExecutorEvents extends EventEmitter {
       ? { ...executionContext.context, ...extraContext }
       : undefined;
 
-    const stepType = this.getStepType(step);
+    const stepType = getStepType(step);
 
     this.emit(FlowEventType.STEP_START, {
       timestamp: Date.now(),
@@ -227,7 +227,7 @@ export class FlowExecutorEvents extends EventEmitter {
   emitStepComplete(step: Step, result: StepExecutionResult, startTime: number): void {
     if (!this.options.emitStepEvents) return;
 
-    const stepType = this.getStepType(step);
+    const stepType = getStepType(step);
     const resultData = this.options.includeResults ? result : { type: result.type };
 
     this.emit(FlowEventType.STEP_COMPLETE, {
@@ -246,7 +246,7 @@ export class FlowExecutorEvents extends EventEmitter {
   emitStepError(step: Step, error: Error, startTime: number): void {
     if (!this.options.emitStepEvents) return;
 
-    const stepType = this.getStepType(step);
+    const stepType = getStepType(step);
 
     this.emit(FlowEventType.STEP_ERROR, {
       timestamp: Date.now(),
@@ -283,17 +283,5 @@ export class FlowExecutorEvents extends EventEmitter {
       type: FlowEventType.DEPENDENCY_RESOLVED,
       orderedSteps,
     } as DependencyResolvedEvent);
-  }
-
-  /**
-   * Helper to determine step type
-   */
-  private getStepType(step: Step): string {
-    if (step.request) return 'request';
-    if (step.loop) return 'loop';
-    if (step.condition) return 'condition';
-    if (step.transform) return 'transform';
-    if (step.stop) return 'stop';
-    return 'unknown';
   }
 }


### PR DESCRIPTION
## Summary
- import `getStepType` from `types`
- remove duplicate helper in `flow-executor-events`
- update coverage thresholds

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`
- `npm test`
