### PR TITLE
refactor: make ReferenceResolutionError value unknown

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,8 +14,8 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      branches: 92.31,
-      functions: 96.55,
+      branches: 92.33,
+      functions: 96.57,
       lines: 97.91,
       statements: 97.69,
     },

--- a/src/reference-resolver/errors.ts
+++ b/src/reference-resolver/errors.ts
@@ -44,7 +44,7 @@ export class ReferenceResolutionError extends ReferenceResolverError {
   constructor(
     message: string,
     public readonly path: string,
-    public readonly value: any,
+    public readonly value: unknown,
     cause?: Error,
   ) {
     super(message, cause);


### PR DESCRIPTION
## Summary
- enforce explicit handling of ReferenceResolutionError value property
- update Jest coverage thresholds

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`
- `npm test`
