### PR TITLE
feat: strongly type step events

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,10 +14,10 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      branches: 92.31,
-      functions: 96.55,
+      branches: 92.33,
+      functions: 96.57,
       lines: 97.91,
-      statements: 97.69,
+      statements: 97.7,
     },
   },
 };

--- a/src/__tests__/flow-executor-events.test.ts
+++ b/src/__tests__/flow-executor-events.test.ts
@@ -2,6 +2,7 @@ import { FlowExecutor, FlowEventType } from '../index';
 import { TestLogger } from '../util/logger';
 import { Flow, JsonRpcRequest } from '../types';
 import { FlowExecutorEvents } from '../util/flow-executor-events';
+import { StepType } from '../step-executors';
 
 describe('FlowExecutor Events', () => {
   const simpleFlow: Flow = {
@@ -412,7 +413,7 @@ describe('FlowExecutor Events', () => {
 
     // Verify the step type was considered "unknown"
     expect(events.length).toBeGreaterThan(0);
-    expect(events[0].data.stepType).toBe('unknown');
+    expect(events[0].data.stepType).toBe(StepType.Unknown);
   });
 
   it('should handle nested step errors correctly', async () => {
@@ -666,7 +667,7 @@ describe('FlowExecutor Events', () => {
     expect(errorEvents[0].stepName).toBe('errorStep');
     expect(errorEvents[0].error).toBe(testError);
     expect(errorEvents[0].duration).toBeGreaterThanOrEqual(100);
-    expect(errorEvents[0].stepType).toBe('request');
+    expect(errorEvents[0].stepType).toBe(StepType.Request);
   });
 
   it('should not emit step error events when disabled', async () => {
@@ -771,12 +772,12 @@ describe('FlowExecutor Events', () => {
 
     // Verify all step types were correctly identified
     expect(events.length).toBe(6);
-    expect(events[0].stepType).toBe('loop');
-    expect(events[1].stepType).toBe('request');
-    expect(events[2].stepType).toBe('condition');
-    expect(events[3].stepType).toBe('transform');
-    expect(events[4].stepType).toBe('stop');
-    expect(events[5].stepType).toBe('unknown');
+    expect(events[0].stepType).toBe(StepType.Loop);
+    expect(events[1].stepType).toBe(StepType.Request);
+    expect(events[2].stepType).toBe(StepType.Condition);
+    expect(events[3].stepType).toBe(StepType.Transform);
+    expect(events[4].stepType).toBe(StepType.Stop);
+    expect(events[5].stepType).toBe(StepType.Unknown);
   });
 
   it('should emit dependency resolved events with ordered steps', async () => {

--- a/src/expression-evaluator/safe-evaluator.ts
+++ b/src/expression-evaluator/safe-evaluator.ts
@@ -145,7 +145,7 @@ export class SafeExpressionEvaluator {
    * @param stepType Optional step type for timeout resolution
    * @returns The resolved timeout value
    */
-  getExpressionTimeout(step?: Step, stepType?: string): number {
+  getExpressionTimeout(step?: Step, stepType?: StepType): number {
     if (this.policyResolver && step && stepType) {
       return this.policyResolver.resolveExpressionTimeout(step, stepType as any);
     }
@@ -295,7 +295,7 @@ export class SafeExpressionEvaluator {
     startTime: number,
     expression: string,
     step?: Step,
-    stepType?: string,
+    stepType?: StepType,
   ): void {
     const currentTime = Date.now();
     const elapsedTime = currentTime - startTime;
@@ -667,7 +667,7 @@ export class SafeExpressionEvaluator {
     startTime: number,
     expression: string,
     step?: Step,
-    stepType?: string,
+    stepType?: StepType,
   ): unknown {
     this.checkTimeout(startTime, expression, step, stepType);
 

--- a/src/step-executors/types.ts
+++ b/src/step-executors/types.ts
@@ -55,6 +55,7 @@ export enum StepType {
   Condition = 'condition',
   Transform = 'transform',
   Stop = 'stop',
+  Unknown = 'unknown',
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,4 @@
-import type { StepType } from './step-executors/types';
-import { TransformOperation } from './step-executors/types';
+import { StepType, TransformOperation } from './step-executors/types';
 import { ReferenceResolver } from './reference-resolver';
 import { SafeExpressionEvaluator } from './expression-evaluator/safe-evaluator';
 import { Logger } from './util/logger';
@@ -206,11 +205,11 @@ export interface DependencyGraph {
 /**
  * Utility to determine the step type from a Step object
  */
-export function getStepType(step: Step): string {
-  if (step.request) return 'request';
-  if (step.loop) return 'loop';
-  if (step.condition) return 'condition';
-  if (step.transform) return 'transform';
-  if (step.stop) return 'stop';
-  return 'unknown';
+export function getStepType(step: Step): StepType {
+  if (step.request) return StepType.Request;
+  if (step.loop) return StepType.Loop;
+  if (step.condition) return StepType.Condition;
+  if (step.transform) return StepType.Transform;
+  if (step.stop) return StepType.Stop;
+  return StepType.Unknown;
 }

--- a/src/util/flow-executor-events.ts
+++ b/src/util/flow-executor-events.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 import { Step, StepExecutionContext } from '../types';
-import { StepExecutionResult } from '../step-executors';
+import { StepExecutionResult, StepType } from '../step-executors';
 
 /**
  * Event types emitted by the FlowExecutor
@@ -59,7 +59,7 @@ export interface FlowErrorEvent extends FlowEvent {
 export interface StepStartEvent extends FlowEvent {
   type: FlowEventType.STEP_START;
   stepName: string;
-  stepType: string;
+  stepType: StepType;
   context?: Record<string, any>;
 }
 
@@ -69,8 +69,8 @@ export interface StepStartEvent extends FlowEvent {
 export interface StepCompleteEvent extends FlowEvent {
   type: FlowEventType.STEP_COMPLETE;
   stepName: string;
-  stepType: string;
-  result: any;
+  stepType: StepType;
+  result: StepExecutionResult;
   duration: number;
 }
 
@@ -80,7 +80,7 @@ export interface StepCompleteEvent extends FlowEvent {
 export interface StepErrorEvent extends FlowEvent {
   type: FlowEventType.STEP_ERROR;
   stepName: string;
-  stepType: string;
+  stepType: StepType;
   error: Error;
   duration: number;
 }
@@ -288,12 +288,12 @@ export class FlowExecutorEvents extends EventEmitter {
   /**
    * Helper to determine step type
    */
-  private getStepType(step: Step): string {
-    if (step.request) return 'request';
-    if (step.loop) return 'loop';
-    if (step.condition) return 'condition';
-    if (step.transform) return 'transform';
-    if (step.stop) return 'stop';
-    return 'unknown';
+  private getStepType(step: Step): StepType {
+    if (step.request) return StepType.Request;
+    if (step.loop) return StepType.Loop;
+    if (step.condition) return StepType.Condition;
+    if (step.transform) return StepType.Transform;
+    if (step.stop) return StepType.Stop;
+    return StepType.Unknown;
   }
 }


### PR DESCRIPTION
## Summary
- type step events with StepType and StepExecutionResult
- add `Unknown` to `StepType` enum
- use the enum in event emitter helpers
- adapt tests for new event typing
- update coverage thresholds

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`
- `npm test`