### PR TITLE
feat: re-export StepExecutor classes

### DIFF
--- a/src/__tests__/index-step-executors.test.ts
+++ b/src/__tests__/index-step-executors.test.ts
@@ -1,0 +1,17 @@
+import {
+  RequestStepExecutor,
+  LoopStepExecutor,
+  ConditionStepExecutor,
+  TransformStepExecutor,
+  StopStepExecutor,
+} from '../index';
+
+describe('index exports StepExecutors', () => {
+  it('re-exports all StepExecutor classes', () => {
+    expect(RequestStepExecutor).toBeDefined();
+    expect(LoopStepExecutor).toBeDefined();
+    expect(ConditionStepExecutor).toBeDefined();
+    expect(TransformStepExecutor).toBeDefined();
+    expect(StopStepExecutor).toBeDefined();
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,13 @@
 /* istanbul ignore file */
 export { Flow, Step, JsonRpcRequest } from './types';
 export { StepType } from './step-executors/types';
+export {
+  RequestStepExecutor,
+  LoopStepExecutor,
+  ConditionStepExecutor,
+  TransformStepExecutor,
+  StopStepExecutor,
+} from './step-executors';
 export { FlowExecutor, FlowExecutorOptions, DEFAULT_RETRY_POLICY } from './flow-executor';
 export { SafeExpressionEvaluator } from './expression-evaluator/safe-evaluator';
 export {


### PR DESCRIPTION
## Summary
- re-export all StepExecutor classes from the package root
- add tests ensuring the root index exposes the executors

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`
- `npm test`
