### PR TITLE
feat: export TimeoutError from index

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ export {
 } from './util/flow-executor-events';
 
 // Export error handling related types
-export { FlowError, ExecutionError, ValidationError, StateError } from './errors/base';
+export { FlowError, ExecutionError, ValidationError, TimeoutError, StateError } from './errors';
 export { ErrorCode, ErrorCategory } from './errors/codes';
 export { RetryPolicy, RetryableOperation } from './errors/recovery';
 


### PR DESCRIPTION
## Summary
- export TimeoutError from the package entry point

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`
- `npm test`
