### PR TITLE
Add typed context and policy overrides

### DIFF
--- a/src/__tests__/step-executors/stop-executor.test.ts
+++ b/src/__tests__/step-executors/stop-executor.test.ts
@@ -1,5 +1,6 @@
 import { StopStepExecutor } from '../../step-executors/stop-executor';
 import { noLogger } from '../../util/logger';
+import { createMockContext } from '../test-utils';
 
 describe('StopStepExecutor', () => {
   let executor: StopStepExecutor;
@@ -16,7 +17,8 @@ describe('StopStepExecutor', () => {
       },
     };
 
-    const result = await executor.execute(step, {});
+    const context = createMockContext();
+    const result = await executor.execute(step, context);
 
     expect(result.type).toBe('stop');
     expect(result.result.endWorkflow).toBe(true);
@@ -31,7 +33,8 @@ describe('StopStepExecutor', () => {
       },
     };
 
-    const result = await executor.execute(step, {});
+    const context = createMockContext();
+    const result = await executor.execute(step, context);
 
     expect(result.type).toBe('stop');
     expect(result.result.endWorkflow).toBe(false);
@@ -44,7 +47,8 @@ describe('StopStepExecutor', () => {
       stop: {},
     };
 
-    const result = await executor.execute(step, {});
+    const context = createMockContext();
+    const result = await executor.execute(step, context);
 
     expect(result.type).toBe('stop');
     expect(result.result.endWorkflow).toBe(false);
@@ -60,7 +64,8 @@ describe('StopStepExecutor', () => {
       },
     };
 
-    await expect(executor.execute(invalidStep as any, {})).rejects.toThrow(
+    const context = createMockContext();
+    await expect(executor.execute(invalidStep as any, context)).rejects.toThrow(
       'Invalid step type for StopStepExecutor',
     );
   });

--- a/src/__tests__/test-utils.ts
+++ b/src/__tests__/test-utils.ts
@@ -1,4 +1,4 @@
-import { StepExecutionContext } from '../types';
+import { StepExecutionContext, ExecutionContextData } from '../types';
 import { SafeExpressionEvaluator } from '../expression-evaluator/safe-evaluator';
 import { ReferenceResolver } from '../reference-resolver';
 import { noLogger } from '../util/logger';
@@ -8,7 +8,7 @@ import { noLogger } from '../util/logger';
  */
 export function createMockContext(
   initialStepResults: Record<string, any> = {},
-  initialContext: Record<string, any> = {},
+  initialContext: ExecutionContextData = {},
 ): StepExecutionContext {
   const stepResults = new Map(Object.entries(initialStepResults));
   const context = { ...initialContext };

--- a/src/flow-executor.ts
+++ b/src/flow-executor.ts
@@ -1,7 +1,14 @@
 import { ReferenceResolver } from './reference-resolver';
 import { SafeExpressionEvaluator } from './expression-evaluator/safe-evaluator';
 import { DependencyResolver } from './dependency-resolver';
-import { Flow, Step, StepExecutionContext, JsonRpcHandler } from './types';
+import {
+  Flow,
+  Step,
+  StepExecutionContext,
+  JsonRpcHandler,
+  ExecutionContextData,
+  PolicyOverrides,
+} from './types';
 import {
   StepExecutor,
   StepExecutionResult,
@@ -55,8 +62,8 @@ export class FlowExecutor {
   public expressionEvaluator: SafeExpressionEvaluator;
   public events: FlowExecutorEvents;
 
-  private context: Record<string, any>;
-  private stepResults: Map<string, any>;
+  private context: ExecutionContextData;
+  private stepResults: Map<string, unknown>;
   private executionContext: StepExecutionContext;
   private stepExecutors: StepExecutor[];
   private logger: Logger;
@@ -135,7 +142,7 @@ export class FlowExecutor {
     };
 
     // Initialize PolicyResolver for policy-based execution
-    const policyOverrides: Record<string, any> = {};
+    const policyOverrides: PolicyOverrides = {};
     if (options?.retryPolicy) {
       policyOverrides.retryPolicy = options.retryPolicy;
     }
@@ -265,7 +272,7 @@ export class FlowExecutor {
    */
   private async executeStep(
     step: Step,
-    extraContext: Record<string, any> = {},
+    extraContext: ExecutionContextData = {},
     signal?: AbortSignal,
   ): Promise<StepExecutionResult> {
     const stepStartTime = Date.now();

--- a/src/step-executors/condition-executor.ts
+++ b/src/step-executors/condition-executor.ts
@@ -1,11 +1,12 @@
-import { Step, StepExecutionContext } from '../types';
+import { Step, StepExecutionContext, ExecutionContextData } from '../types';
 import { StepExecutor, StepExecutionResult, StepType, ConditionStep } from './types';
 import { Logger } from '../util/logger';
 import { ValidationError, ExecutionError } from '../errors/base';
 import { TimeoutError } from '../errors/timeout-error';
+import { PolicyResolver } from '../util/policy-resolver';
 
 class ConditionStepExecutionError extends ExecutionError {
-  constructor(message: string, context: Record<string, any>, cause?: Error) {
+  constructor(message: string, context: ExecutionContextData, cause?: Error) {
     super(message, { ...context, code: 'EXECUTION_ERROR' }, cause);
     this.name = 'ConditionStepExecutionError';
     Object.setPrototypeOf(this, ConditionStepExecutionError.prototype);
@@ -14,16 +15,16 @@ class ConditionStepExecutionError extends ExecutionError {
 
 export class ConditionStepExecutor implements StepExecutor {
   private logger: Logger;
-  private policyResolver: any;
+  private policyResolver: PolicyResolver;
 
   constructor(
     private executeStep: (
       step: Step,
-      extraContext?: Record<string, any>,
+      extraContext?: ExecutionContextData,
       signal?: AbortSignal,
     ) => Promise<StepExecutionResult>,
     logger: Logger,
-    policyResolver: any,
+    policyResolver: PolicyResolver,
   ) {
     this.logger = logger.createNested('ConditionStepExecutor');
     this.policyResolver = policyResolver;
@@ -36,7 +37,7 @@ export class ConditionStepExecutor implements StepExecutor {
   async execute(
     step: Step,
     context: StepExecutionContext,
-    extraContext: Record<string, any> = {},
+    extraContext: ExecutionContextData = {},
     signal?: AbortSignal,
   ): Promise<StepExecutionResult> {
     if (!this.canExecute(step)) {

--- a/src/step-executors/loop-executor.ts
+++ b/src/step-executors/loop-executor.ts
@@ -1,11 +1,11 @@
-import { Step, StepExecutionContext } from '../types';
+import { Step, StepExecutionContext, ExecutionContextData } from '../types';
 import { StepExecutor, StepExecutionResult, StepType, LoopStep } from './types';
 import { Logger } from '../util/logger';
 import { ValidationError, LoopStepExecutionError } from '../errors/base';
 
 export type ExecuteStep = (
   step: Step,
-  extraContext?: Record<string, any>,
+  extraContext?: ExecutionContextData,
   signal?: AbortSignal,
 ) => Promise<StepExecutionResult>;
 
@@ -26,7 +26,7 @@ export class LoopStepExecutor implements StepExecutor {
   async execute(
     step: Step,
     context: StepExecutionContext,
-    extraContext: Record<string, any> = {},
+    extraContext: ExecutionContextData = {},
     signal?: AbortSignal,
   ): Promise<StepExecutionResult> {
     if (!this.canExecute(step)) {

--- a/src/step-executors/request-executor.ts
+++ b/src/step-executors/request-executor.ts
@@ -1,4 +1,10 @@
-import { Step, StepExecutionContext, JsonRpcHandler } from '../types';
+import {
+  Step,
+  StepExecutionContext,
+  JsonRpcHandler,
+  JsonRpcHandlerOptions,
+  ExecutionContextData,
+} from '../types';
 import { StepExecutor, StepExecutionResult, JsonRpcRequestError, StepType } from './types';
 import { Logger } from '../util/logger';
 import { RequestStep } from './types';
@@ -61,7 +67,7 @@ export class RequestStepExecutor implements StepExecutor {
   async execute(
     step: Step,
     _context: StepExecutionContext,
-    extraContext: Record<string, any> = {},
+    extraContext: ExecutionContextData = {},
     signal?: AbortSignal,
   ): Promise<StepExecutionResult> {
     if (!this.canExecute(step)) {
@@ -136,7 +142,7 @@ export class RequestStepExecutor implements StepExecutor {
         });
 
         // Create options object with AbortSignal if available
-        const options: Record<string, any> = {};
+        const options: JsonRpcHandlerOptions = {};
 
         // Use either our timeout's abort signal or the one from context or the passed signal
         if (abortController?.signal) {

--- a/src/step-executors/stop-executor.ts
+++ b/src/step-executors/stop-executor.ts
@@ -1,4 +1,4 @@
-import { Step } from '../types';
+import { Step, StepExecutionContext, ExecutionContextData } from '../types';
 import { StepExecutor, StepExecutionResult, StepType } from './types';
 import { Logger } from '../util/logger';
 import { ValidationError } from '../errors/base';
@@ -25,8 +25,8 @@ export class StopStepExecutor implements StepExecutor {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async execute(
     step: Step,
-    context: any, // eslint-disable-line @typescript-eslint/no-unused-vars
-    extraContext?: Record<string, any>, // eslint-disable-line @typescript-eslint/no-unused-vars
+    context: StepExecutionContext, // eslint-disable-line @typescript-eslint/no-unused-vars
+    extraContext?: ExecutionContextData, // eslint-disable-line @typescript-eslint/no-unused-vars
     signal?: AbortSignal, // eslint-disable-line @typescript-eslint/no-unused-vars
   ): Promise<StepExecutionResult> {
     if (!this.canExecute(step)) {

--- a/src/step-executors/transform-executor.ts
+++ b/src/step-executors/transform-executor.ts
@@ -1,4 +1,4 @@
-import { Step, StepExecutionContext } from '../types';
+import { Step, StepExecutionContext, ExecutionContextData } from '../types';
 import {
   StepExecutor,
   StepExecutionResult,
@@ -22,7 +22,7 @@ export class TransformExecutor {
   constructor(
     private expressionEvaluator: SafeExpressionEvaluator,
     private referenceResolver: ReferenceResolver,
-    private context: Record<string, any>,
+    private context: ExecutionContextData,
     logger: Logger,
   ) {
     this.logger = logger.createNested('TransformExecutor');
@@ -392,7 +392,7 @@ export class TransformStepExecutor implements StepExecutor {
   constructor(
     expressionEvaluator: SafeExpressionEvaluator,
     referenceResolver: ReferenceResolver,
-    context: Record<string, any>,
+    context: ExecutionContextData,
     logger: Logger,
     policyResolver: PolicyResolver,
   ) {
@@ -413,7 +413,7 @@ export class TransformStepExecutor implements StepExecutor {
   async execute(
     step: Step,
     context: StepExecutionContext,
-    extraContext: Record<string, any> = {},
+    extraContext: ExecutionContextData = {},
     signal?: AbortSignal,
   ): Promise<StepExecutionResult> {
     if (!this.canExecute(step)) {

--- a/src/step-executors/types.ts
+++ b/src/step-executors/types.ts
@@ -1,4 +1,4 @@
-import { Step } from '../types';
+import { Step, ErrorData } from '../types';
 import { StepExecutionContext } from '../types';
 import { RetryPolicy } from '../errors/recovery';
 
@@ -37,11 +37,7 @@ export class JsonRpcRequestError extends Error {
  */
 export interface StepExecutionResult<T = any> {
   result?: T;
-  error?: {
-    code: number;
-    message: string;
-    data?: any;
-  };
+  error?: ErrorData;
   type: StepType;
   metadata?: Record<string, any>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,8 +2,33 @@ import { StepType, TransformOperation } from './step-executors/types';
 import { ReferenceResolver } from './reference-resolver';
 import { SafeExpressionEvaluator } from './expression-evaluator/safe-evaluator';
 import { Logger } from './util/logger';
+import { RetryPolicy } from './errors/recovery';
 
 export type { StepType } from './step-executors/types';
+
+/**
+ * Context object passed to flows and steps
+ */
+export interface ExecutionContextData {
+  [key: string]: unknown;
+}
+
+/**
+ * Overrides that can be provided to the PolicyResolver
+ */
+export interface PolicyOverrides {
+  retryPolicy?: RetryPolicy;
+  [key: string]: unknown;
+}
+
+/**
+ * Standard structure for error objects
+ */
+export interface ErrorData {
+  code: number;
+  message: string;
+  data?: unknown;
+}
 
 /**
  * Policies for a specific step type or as a default for all steps
@@ -91,7 +116,7 @@ export interface Flow {
   name: string;
   description: string;
   steps: Step[];
-  context?: Record<string, any>;
+  context?: ExecutionContextData;
   /**
    * Global and step-level policies for the flow (metaschema-compliant)
    */
@@ -168,8 +193,8 @@ export type JsonRpcHandler = (
 export interface StepExecutionContext {
   referenceResolver: ReferenceResolver;
   expressionEvaluator: SafeExpressionEvaluator;
-  stepResults: Map<string, any>;
-  context: Record<string, any>;
+  stepResults: Map<string, unknown>;
+  context: ExecutionContextData;
   logger: Logger;
   /**
    * AbortSignal that can be used to cancel operations

--- a/src/util/policy-resolver.ts
+++ b/src/util/policy-resolver.ts
@@ -1,4 +1,4 @@
-import type { Flow, Step } from '../types';
+import type { Flow, Step, PolicyOverrides } from '../types';
 import type { StepType } from '../step-executors/types';
 import { Logger, defaultLogger } from '../util/logger';
 import { DEFAULT_TIMEOUTS } from '../constants/timeouts';
@@ -18,9 +18,9 @@ import { DEFAULT_RETRY_POLICY } from '../flow-executor';
 export class PolicyResolver {
   private flow: Flow;
   private logger: Logger;
-  private overrides: Record<string, any>;
+  private overrides: PolicyOverrides;
 
-  constructor(flow: Flow, logger: Logger = defaultLogger, overrides: Record<string, any> = {}) {
+  constructor(flow: Flow, logger: Logger = defaultLogger, overrides: PolicyOverrides = {}) {
     this.flow = flow;
     this.logger = logger.createNested('PolicyResolver');
     this.overrides = overrides;


### PR DESCRIPTION
## Summary
- introduce `ExecutionContextData`, `PolicyOverrides`, and `ErrorData` interfaces
- type `PolicyResolver` and executors with new interfaces
- update FlowExecutor and step executors to use typed context
- adjust StopStepExecutor tests for new signature

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68473cdada24832fa8e99a5ea435a2a2