### PR TITLE
feat: improve logging with warnings

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,7 +14,7 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      branches: 92.61,
+      branches: 92.65,
       functions: 96.56,
       lines: 97.91,
       statements: 97.82,

--- a/src/__tests__/step-executors/request-executor.test.ts
+++ b/src/__tests__/step-executors/request-executor.test.ts
@@ -300,6 +300,9 @@ describe('RequestStepExecutor', () => {
     expect(result.metadata).toBeDefined();
     expect(result?.metadata?.hasError).toBe(true);
     expect(result.result.error).toEqual({ message: 'Custom error' });
+
+    const warnLogs = testLogger.getLogs().filter((l) => l.level === 'warn');
+    expect(warnLogs.length).toBeGreaterThan(0);
   });
 
   it('throws error when given invalid step type', async () => {

--- a/src/errors/__tests__/recovery.test.ts
+++ b/src/errors/__tests__/recovery.test.ts
@@ -48,6 +48,9 @@ describe('RetryableOperation', () => {
 
       expect(result).toBe('success');
       expect(operation).toHaveBeenCalledTimes(2);
+
+      const warnings = testLogger.getLogs().filter((l) => l.level === 'warn');
+      expect(warnings.length).toBeGreaterThan(0);
     });
 
     it('should throw immediately on non-retryable error', async () => {

--- a/src/errors/recovery.ts
+++ b/src/errors/recovery.ts
@@ -118,6 +118,12 @@ export class RetryableOperation<T> {
           );
         }
 
+        this.logger.warn('Retrying operation after failure', {
+          attempt,
+          maxAttempts: this.policy.maxAttempts,
+          error: error instanceof Error ? error.message : String(error),
+        });
+
         attempt++;
 
         const delay = this.calculateDelay(attempt);

--- a/src/step-executors/request-executor.ts
+++ b/src/step-executors/request-executor.ts
@@ -179,6 +179,14 @@ export class RequestStepExecutor implements StepExecutor {
           result: raceResult,
         });
 
+        if (raceResult && typeof raceResult === 'object' && 'error' in raceResult) {
+          this.logger.warn('Request returned error response', {
+            stepName: step.name,
+            requestId,
+            error: (raceResult as any).error,
+          });
+        }
+
         return {
           result: raceResult,
           type: StepType.Request,


### PR DESCRIPTION
## Summary
- warn when retryable operations fail and will be retried
- log warning when a JSON-RPC request returns an error response
- test new warning logs
- update coverage thresholds

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68473df22a3c832f977a14b15708700b