### PR TITLE
Implement OpenRPC discovery validation

### DIFF
--- a/src/__tests__/flow-executor-events-emission.test.ts
+++ b/src/__tests__/flow-executor-events-emission.test.ts
@@ -92,6 +92,8 @@ describe('FlowExecutor event emission', () => {
     };
     jsonRpcHandler.mockRejectedValueOnce(new Error('fail!'));
     const executor = new FlowExecutor(flow, jsonRpcHandler, { logger: testLogger });
+    // rpc.discover consumes the first mockRejectedValueOnce, reapply for the step
+    jsonRpcHandler.mockRejectedValueOnce(new Error('fail!'));
     const events: { type: string; payload: any }[] = [];
     const fevents = executor.events;
     fevents.on(FlowEventType.STEP_ERROR, (payload) =>

--- a/src/__tests__/openrpc-validation.test.ts
+++ b/src/__tests__/openrpc-validation.test.ts
@@ -1,0 +1,64 @@
+import { FlowExecutor } from '../flow-executor';
+import { Flow } from '../types';
+import { createMockJsonRpcHandler } from './test-utils';
+import { TestLogger } from '../util/logger';
+import { ValidationError } from '../errors/base';
+
+describe('OpenRPC discovery and validation', () => {
+  it('validates methods against discovered document', async () => {
+    const openRpc = {
+      openrpc: '1.2.6',
+      info: { title: 'test', version: '1' },
+      methods: [{ name: 'foo' }],
+    };
+    const handler = createMockJsonRpcHandler({
+      'rpc.discover': openRpc,
+      foo: { success: true },
+    });
+    const flow: Flow = {
+      name: 'doc-flow',
+      description: '',
+      steps: [{ name: 's1', request: { method: 'foo', params: {} } }],
+    };
+    const logger = new TestLogger('openrpc');
+    const executor = new FlowExecutor(flow, handler, logger);
+    const results = await executor.execute();
+    expect(results.get('s1').result).toEqual({ success: true });
+  });
+
+  it('throws when method is not in document', async () => {
+    const openRpc = {
+      openrpc: '1.2.6',
+      info: { title: 'test', version: '1' },
+      methods: [{ name: 'foo' }],
+    };
+    const handler = createMockJsonRpcHandler({
+      'rpc.discover': openRpc,
+      bar: { ok: true },
+    });
+    const flow: Flow = {
+      name: 'invalid-method',
+      description: '',
+      steps: [{ name: 'bad', request: { method: 'bar', params: {} } }],
+    };
+    const executor = new FlowExecutor(flow, handler, new TestLogger('openrpc'));
+    await expect(executor.execute()).rejects.toThrow(ValidationError);
+  });
+
+  it('continues when discovery fails', async () => {
+    const handler = jest.fn().mockImplementation((req) => {
+      if (req.method === 'rpc.discover') {
+        return Promise.reject(new Error('unsupported'));
+      }
+      return Promise.resolve({ ok: true });
+    });
+    const flow: Flow = {
+      name: 'no-doc',
+      description: '',
+      steps: [{ name: 'step', request: { method: 'any', params: {} } }],
+    };
+    const executor = new FlowExecutor(flow, handler, new TestLogger('openrpc'));
+    const results = await executor.execute();
+    expect(results.get('step').result).toEqual({ ok: true });
+  });
+});

--- a/src/__tests__/test-utils.ts
+++ b/src/__tests__/test-utils.ts
@@ -32,6 +32,9 @@ export function createMockJsonRpcHandler(_mockResponses: Record<string, any> = {
   return jest.fn().mockImplementation((request) => {
     const response = _mockResponses[request.method];
     if (response === undefined) {
+      if (request.method === 'rpc.discover') {
+        return Promise.resolve({});
+      }
       throw new Error(`No mock response for method: ${request.method}`);
     }
     return Promise.resolve(response);


### PR DESCRIPTION
## Summary
- validate request steps against rpc.discover'd document
- ignore rpc.discover calls in mocks
- adjust failing event emission test
- test OpenRPC validation behaviour

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68473ec5924c832f9e9b6d327c9e0564