### PR TITLE
feat: emit progress for loop steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,7 @@ for a full working example.
 | `step:complete`       | Emitted when a step execution completes            |
 | `step:error`          | Emitted when a step execution fails                |
 | `step:skip`           | Emitted when a step is skipped                     |
+| `step:progress`       | Emitted to report progress of long-running steps   |
 | `dependency:resolved` | Emitted when dependencies are resolved             |
 
 ### Event Payloads
@@ -448,14 +449,15 @@ for a full working example.
 Each emitted event carries a typed payload. Below is a quick reference of the
 most useful fields:
 
-| Event           | Key fields                                   |
-| --------------- | -------------------------------------------- |
-| `flow:start`    | `flowName`, `orderedSteps`                   |
-| `flow:complete` | `flowName`, `results`, `duration`            |
-| `flow:error`    | `flowName`, `error`, `duration`              |
-| `step:start`    | `stepName`, `stepType`, `context?`           |
-| `step:complete` | `stepName`, `stepType`, `result`, `duration` |
-| `step:error`    | `stepName`, `stepType`, `error`, `duration`  |
+| Event           | Key fields                                                        |
+| --------------- | ----------------------------------------------------------------- |
+| `flow:start`    | `flowName`, `orderedSteps`                                        |
+| `flow:complete` | `flowName`, `results`, `duration`                                 |
+| `flow:error`    | `flowName`, `error`, `duration`                                   |
+| `step:start`    | `stepName`, `stepType`, `context?`                                |
+| `step:complete` | `stepName`, `stepType`, `result`, `duration`                      |
+| `step:error`    | `stepName`, `stepType`, `error`, `duration`                       |
+| `step:progress` | `stepName`, `stepType`, `iteration`, `totalIterations`, `percent` |
 
 ### Configuration Options
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,9 +15,9 @@ module.exports = {
   coverageThreshold: {
     global: {
       branches: 92.61,
-      functions: 96.56,
-      lines: 97.91,
-      statements: 97.82,
+      functions: 96.57,
+      lines: 97.92,
+      statements: 97.83,
     },
   },
 };

--- a/src/__tests__/flow-executor-events-emission.test.ts
+++ b/src/__tests__/flow-executor-events-emission.test.ts
@@ -134,4 +134,32 @@ describe('FlowExecutor event emission', () => {
     expect(events.some((e) => e.type === FlowEventType.STEP_SKIP)).toBe(true);
     expect(events.some((e) => e.type === FlowEventType.FLOW_COMPLETE)).toBe(true);
   });
+
+  it('emits step progress events for loop steps', async () => {
+    const flow: Flow = {
+      name: 'ProgressFlow',
+      description: 'progress test',
+      steps: [
+        {
+          name: 'loopStep',
+          loop: {
+            over: '${context.items}',
+            as: 'item',
+            step: { name: 'inner', request: { method: 'foo', params: {} } },
+          },
+        },
+      ],
+      context: { items: [1, 2, 3] },
+    };
+
+    const executor = new FlowExecutor(flow, jsonRpcHandler, { logger: testLogger });
+    const progress: any[] = [];
+    executor.events.on(FlowEventType.STEP_PROGRESS, (p) => progress.push(p));
+
+    await executor.execute();
+
+    expect(progress.length).toBe(3);
+    expect(progress[0].iteration).toBe(1);
+    expect(progress[2].percent).toBe(100);
+  });
 });

--- a/src/__tests__/flow-executor-events.test.ts
+++ b/src/__tests__/flow-executor-events.test.ts
@@ -1027,6 +1027,36 @@ describe('FlowExecutor Events', () => {
     expect(disabledEvents.length).toBe(0);
   });
 
+  it('should emit step progress events', () => {
+    const events = new FlowExecutorEvents({ emitStepEvents: true });
+    const received: any[] = [];
+    const testStep = {
+      name: 'loop',
+      loop: { over: '${items}', as: 'item', step: { name: 'inner' } },
+    } as any;
+
+    events.on(FlowEventType.STEP_PROGRESS, (data) => received.push(data));
+
+    events.emitStepProgress(testStep, 2, 5);
+
+    expect(received.length).toBe(1);
+    expect(received[0].iteration).toBe(2);
+    expect(received[0].totalIterations).toBe(5);
+    expect(received[0].percent).toBe(40);
+  });
+
+  it('should not emit step progress when step events are disabled', () => {
+    const events = new FlowExecutorEvents({ emitStepEvents: false });
+    const received: any[] = [];
+    const testStep = { name: 'loop', loop: { over: '${items}', as: 'item' } } as any;
+
+    events.on(FlowEventType.STEP_PROGRESS, (data) => received.push(data));
+
+    events.emitStepProgress(testStep, 1, 3);
+
+    expect(received.length).toBe(0);
+  });
+
   it('should not emit flow complete event when emitFlowEvents is false', async () => {
     // Testing specifically the early return in emitFlowComplete when emitFlowEvents is false
 

--- a/src/flow-executor.ts
+++ b/src/flow-executor.ts
@@ -147,7 +147,11 @@ export class FlowExecutor {
     // Initialize step executors in order of specificity
     this.stepExecutors = [
       this.createRequestStepExecutor(),
-      new LoopStepExecutor(this.executeStep.bind(this), this.logger),
+      new LoopStepExecutor(
+        this.executeStep.bind(this),
+        this.logger,
+        this.events.emitStepProgress.bind(this.events),
+      ),
       new ConditionStepExecutor(this.executeStep.bind(this), this.logger, this.policyResolver),
       new TransformStepExecutor(
         this.expressionEvaluator,

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ export {
   StepCompleteEvent,
   StepErrorEvent,
   StepSkipEvent,
+  StepProgressEvent,
   DependencyResolvedEvent,
   FlowEventOptions,
 } from './util/flow-executor-events';

--- a/src/step-executors/loop-executor.ts
+++ b/src/step-executors/loop-executor.ts
@@ -15,6 +15,7 @@ export class LoopStepExecutor implements StepExecutor {
   constructor(
     private executeStep: ExecuteStep,
     logger: Logger,
+    private progressCallback?: (step: Step, iteration: number, totalIterations: number) => void,
   ) {
     this.logger = logger.createNested('LoopStepExecutor');
   }
@@ -90,6 +91,8 @@ export class LoopStepExecutor implements StepExecutor {
 
         // Increment iteration count before any processing
         iterationCount++;
+
+        this.progressCallback?.(step, iterationCount, Math.min(maxIterations, collection.length));
 
         // Create iteration context with array of iterations
         const currentIteration = {

--- a/src/util/flow-executor-events.ts
+++ b/src/util/flow-executor-events.ts
@@ -14,6 +14,7 @@ export enum FlowEventType {
   STEP_COMPLETE = 'step:complete',
   STEP_ERROR = 'step:error',
   STEP_SKIP = 'step:skip',
+  STEP_PROGRESS = 'step:progress',
   DEPENDENCY_RESOLVED = 'dependency:resolved',
 }
 
@@ -93,6 +94,18 @@ export interface StepSkipEvent extends FlowEvent {
   type: FlowEventType.STEP_SKIP;
   stepName: string;
   reason: string;
+}
+
+/**
+ * Step progress event
+ */
+export interface StepProgressEvent extends FlowEvent {
+  type: FlowEventType.STEP_PROGRESS;
+  stepName: string;
+  stepType: StepType;
+  iteration: number;
+  totalIterations: number;
+  percent: number;
 }
 
 /**
@@ -271,6 +284,26 @@ export class FlowExecutorEvents extends EventEmitter {
       stepName: step.name,
       reason,
     } as StepSkipEvent);
+  }
+
+  /**
+   * Emit step progress event
+   */
+  emitStepProgress(step: Step, iteration: number, totalIterations: number): void {
+    if (!this.options.emitStepEvents) return;
+
+    const stepType = getStepType(step);
+    const percent = Math.min(Math.round((iteration / totalIterations) * 100), 100);
+
+    this.emit(FlowEventType.STEP_PROGRESS, {
+      timestamp: Date.now(),
+      type: FlowEventType.STEP_PROGRESS,
+      stepName: step.name,
+      stepType,
+      iteration,
+      totalIterations,
+      percent,
+    } as StepProgressEvent);
   }
 
   /**


### PR DESCRIPTION
## Summary
- add `step:progress` event type
- emit progress updates from loop executor
- expose new event interface
- document new event
- test progress emission and update coverage thresholds

## Testing
- `npm run lint`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684742fc1fe0832f8a24cdf52f8387a0