### PR TITLE
Add flow:finish event

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@ for a full working example.
 | `flow:start`          | Emitted when flow execution begins                 |
 | `flow:complete`       | Emitted when flow execution completes successfully |
 | `flow:error`          | Emitted when flow execution fails                  |
+| `flow:finish`         | Emitted when flow execution ends                   |
 | `step:start`          | Emitted when a step execution begins               |
 | `step:complete`       | Emitted when a step execution completes            |
 | `step:error`          | Emitted when a step execution fails                |
@@ -448,14 +449,15 @@ for a full working example.
 Each emitted event carries a typed payload. Below is a quick reference of the
 most useful fields:
 
-| Event           | Key fields                                   |
-| --------------- | -------------------------------------------- |
-| `flow:start`    | `flowName`, `orderedSteps`                   |
-| `flow:complete` | `flowName`, `results`, `duration`            |
-| `flow:error`    | `flowName`, `error`, `duration`              |
-| `step:start`    | `stepName`, `stepType`, `context?`           |
-| `step:complete` | `stepName`, `stepType`, `result`, `duration` |
-| `step:error`    | `stepName`, `stepType`, `error`, `duration`  |
+| Event           | Key fields                                             |
+| --------------- | ------------------------------------------------------ |
+| `flow:start`    | `flowName`, `orderedSteps`                             |
+| `flow:complete` | `flowName`, `results`, `duration`                      |
+| `flow:error`    | `flowName`, `error`, `duration`                        |
+| `flow:finish`   | `flowName`, `status`, `results?`, `error?`, `duration` |
+| `step:start`    | `stepName`, `stepType`, `context?`                     |
+| `step:complete` | `stepName`, `stepType`, `result`, `duration`           |
+| `step:error`    | `stepName`, `stepType`, `error`, `duration`            |
 
 ### Configuration Options
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,10 +14,10 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      branches: 92.61,
-      functions: 96.56,
-      lines: 97.91,
-      statements: 97.82,
+      branches: 92.63,
+      functions: 96.57,
+      lines: 97.92,
+      statements: 97.83,
     },
   },
 };

--- a/src/__tests__/flow-executor-events-emission.test.ts
+++ b/src/__tests__/flow-executor-events-emission.test.ts
@@ -45,6 +45,9 @@ describe('FlowExecutor event emission', () => {
     fevents.on(FlowEventType.FLOW_ERROR, (payload) =>
       events.push({ type: FlowEventType.FLOW_ERROR, payload }),
     );
+    fevents.on(FlowEventType.FLOW_FINISH, (payload) =>
+      events.push({ type: FlowEventType.FLOW_FINISH, payload }),
+    );
     fevents.on(FlowEventType.STEP_START, (payload) =>
       events.push({ type: FlowEventType.STEP_START, payload }),
     );
@@ -68,6 +71,7 @@ describe('FlowExecutor event emission', () => {
     // Check for flow start and complete
     expect(events.some((e) => e.type === FlowEventType.FLOW_START)).toBe(true);
     expect(events.some((e) => e.type === FlowEventType.FLOW_COMPLETE)).toBe(true);
+    expect(events.some((e) => e.type === FlowEventType.FLOW_FINISH)).toBe(true);
     // Check for step start and complete for each step
     const stepStartEvents = events.filter((e) => e.type === FlowEventType.STEP_START);
     const stepCompleteEvents = events.filter((e) => e.type === FlowEventType.STEP_COMPLETE);
@@ -100,9 +104,13 @@ describe('FlowExecutor event emission', () => {
     fevents.on(FlowEventType.FLOW_ERROR, (payload) =>
       events.push({ type: FlowEventType.FLOW_ERROR, payload }),
     );
+    fevents.on(FlowEventType.FLOW_FINISH, (payload) =>
+      events.push({ type: FlowEventType.FLOW_FINISH, payload }),
+    );
     await expect(executor.execute()).rejects.toThrow('fail!');
     expect(events.some((e) => e.type === FlowEventType.STEP_ERROR)).toBe(true);
     expect(events.some((e) => e.type === FlowEventType.FLOW_ERROR)).toBe(true);
+    expect(events.some((e) => e.type === FlowEventType.FLOW_FINISH)).toBe(true);
   });
 
   it('emits step skip and flow complete if a stop step is encountered', async () => {
@@ -129,9 +137,13 @@ describe('FlowExecutor event emission', () => {
     fevents.on(FlowEventType.FLOW_COMPLETE, (payload) =>
       events.push({ type: FlowEventType.FLOW_COMPLETE, payload }),
     );
+    fevents.on(FlowEventType.FLOW_FINISH, (payload) =>
+      events.push({ type: FlowEventType.FLOW_FINISH, payload }),
+    );
     await executor.execute();
     // Should emit a skip for the second step
     expect(events.some((e) => e.type === FlowEventType.STEP_SKIP)).toBe(true);
     expect(events.some((e) => e.type === FlowEventType.FLOW_COMPLETE)).toBe(true);
+    expect(events.some((e) => e.type === FlowEventType.FLOW_FINISH)).toBe(true);
   });
 });

--- a/src/__tests__/flow-executor-events.test.ts
+++ b/src/__tests__/flow-executor-events.test.ts
@@ -1072,4 +1072,14 @@ describe('FlowExecutor Events', () => {
     // Verify no events were emitted
     expect(receivedEvents.length).toBe(0);
   });
+
+  it('should not emit flow finish event when emitFlowEvents is disabled', () => {
+    const events = new FlowExecutorEvents({ emitFlowEvents: false });
+    const received: any[] = [];
+    events.on(FlowEventType.FLOW_FINISH, (data) => received.push(data));
+
+    events.emitFlowFinish('complete', 'TestFlow', {}, Date.now());
+
+    expect(received.length).toBe(0);
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ export {
   FlowEvent,
   FlowStartEvent,
   FlowCompleteEvent,
+  FlowFinishEvent,
   FlowErrorEvent,
   StepStartEvent,
   StepCompleteEvent,


### PR DESCRIPTION
## Summary
- emit `flow:finish` event for unified completion notifications
- document the new event in the README
- cover the new event with tests
- update coverage thresholds

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684743366d50832f92c925eb85e65da1