### PR TITLE
Add retry timeout example

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,20 @@ Demonstrates halting a flow when a condition is met. See the full example here:
 
 [**src/examples/06-stop-flow.json**](src/examples/06-stop-flow.json)
 
+---
+
+### 5. Timeouts and Retries
+
+Handle flaky endpoints with retry policies and step-level timeouts. See the full example here:
+
+[**src/examples/07-retry-timeout.json**](src/examples/07-retry-timeout.json)
+
+### 6. Abortable Requests
+
+Integrate `AbortSignal` to cancel long running requests.
+
+[**src/examples/abort-signal-example.ts**](src/examples/abort-signal-example.ts)
+
 ## Installation
 
 ```bash

--- a/src/examples/07-retry-timeout.json
+++ b/src/examples/07-retry-timeout.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "../meta-schema.json",
+  "name": "retry-timeout",
+  "description": "Shows retry policy and timeout configuration for a flaky endpoint",
+  "steps": [
+    {
+      "name": "callUnstableService",
+      "request": {
+        "method": "service.unstable",
+        "params": { "foo": "bar" }
+      },
+      "policies": {
+        "retryPolicy": {
+          "maxAttempts": 5,
+          "backoff": { "strategy": "exponential", "initial": 100, "maxDelay": 1000 }
+        },
+        "timeout": { "timeout": 2000 }
+      }
+    }
+  ]
+}

--- a/src/examples/README.md
+++ b/src/examples/README.md
@@ -33,6 +33,17 @@ This directory contains example flows demonstrating various patterns and use cas
    - Combines all primitive operations
    - Shows real-world usage patterns
    - Error handling and data validation
+6. **Stop Flow (06-stop-flow.json)**
+   - Demonstrates halting execution early
+7. **Retry with Timeout (07-retry-timeout.json)**
+   - Custom retry policy with backoff
+   - Step-level timeout control
+
+## TypeScript Examples
+
+- **event-emitter-example.ts** - Stream step updates during execution
+- **abort-signal-example.ts** - Respect `AbortSignal` for request cancellation
+- **error-handling-example.ts** - Demonstrates retry and circuit breaker logic
 
 ## Key Concepts Demonstrated
 


### PR DESCRIPTION
## Summary
- document how to use retry policies and timeouts
- mention abortable requests
- list new flow examples in examples README
- add JSON flow showing retry with timeout policy

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68474499ce10832faa222e2887f2cb0c