### PR TITLE
feat: add correlation metadata to events

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,10 +14,10 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      branches: 92.61,
-      functions: 96.56,
-      lines: 97.91,
-      statements: 97.82,
+      branches: 92.71,
+      functions: 96.57,
+      lines: 98.11,
+      statements: 98.01,
     },
   },
 };

--- a/src/__tests__/abort-skip.test.ts
+++ b/src/__tests__/abort-skip.test.ts
@@ -1,0 +1,27 @@
+import { FlowExecutor } from '../flow-executor';
+import { Flow } from '../types';
+import { FlowEventType } from '../util/flow-executor-events';
+import { TestLogger } from '../util/logger';
+
+describe('Flow abort behavior', () => {
+  it('emits step skip when aborted before execution', async () => {
+    const flow: Flow = {
+      name: 'AbortFlow',
+      description: 'abort',
+      steps: [{ name: 's1', request: { method: 'foo', params: {} } }],
+    };
+
+    const handler = jest.fn().mockResolvedValue({ result: 'ok' });
+    const executor = new FlowExecutor(flow, handler, { logger: new TestLogger('abort') });
+
+    (executor as any).globalAbortController.abort('stop');
+
+    const skips: any[] = [];
+    executor.events.on(FlowEventType.STEP_SKIP, (e) => skips.push(e));
+
+    await expect(executor.execute()).rejects.toThrow('stop');
+
+    expect(skips.length).toBe(1);
+    expect(typeof skips[0].correlationId).toBe('string');
+  });
+});

--- a/src/__tests__/correlation-metadata-events.test.ts
+++ b/src/__tests__/correlation-metadata-events.test.ts
@@ -1,0 +1,51 @@
+import { FlowExecutor } from '../flow-executor';
+import { Flow } from '../types';
+import { FlowEventType } from '../util/flow-executor-events';
+import { TestLogger } from '../util/logger';
+
+describe('Correlation ID and metadata propagation', () => {
+  it('includes correlationId and step metadata in events', async () => {
+    const flow: Flow = {
+      name: 'CorrelationFlow',
+      description: 'flow',
+      steps: [
+        {
+          name: 'step1',
+          request: { method: 'foo', params: {} },
+          metadata: { tag: 'a' },
+        },
+        {
+          name: 'step2',
+          request: { method: 'bar', params: {} },
+          metadata: { tag: 'b' },
+        },
+      ],
+    };
+
+    const handler = jest.fn().mockResolvedValue({ result: 'ok' });
+    const logger = new TestLogger('cid');
+    const executor = new FlowExecutor(flow, handler, {
+      logger,
+      eventOptions: { includeContext: true },
+    });
+
+    const starts: any[] = [];
+    const completes: any[] = [];
+
+    executor.events.on(FlowEventType.STEP_START, (e) => starts.push(e));
+    executor.events.on(FlowEventType.STEP_COMPLETE, (e) => completes.push(e));
+
+    await executor.execute();
+
+    expect(starts.length).toBe(2);
+    expect(completes.length).toBe(2);
+
+    for (let i = 0; i < 2; i++) {
+      expect(typeof starts[i].correlationId).toBe('string');
+      expect(completes[i].correlationId).toBe(starts[i].correlationId);
+      expect(starts[i].metadata.tag).toBe(i === 0 ? 'a' : 'b');
+    }
+
+    expect(starts[0].correlationId).not.toBe(starts[1].correlationId);
+  });
+});

--- a/src/__tests__/flow-executor-events.test.ts
+++ b/src/__tests__/flow-executor-events.test.ts
@@ -660,7 +660,7 @@ describe('FlowExecutor Events', () => {
     // Directly call the emitStepError method
     const testError = new Error('Test error');
     const startTime = Date.now() - 100; // Mock a start time 100ms ago
-    executor.events.emitStepError(testStep as any, testError, startTime);
+    executor.events.emitStepError(testStep as any, testError, startTime, 'ce1');
 
     // Verify error event was emitted
     expect(errorEvents.length).toBe(1);
@@ -699,7 +699,7 @@ describe('FlowExecutor Events', () => {
     // Directly call the emitStepError method
     const testError = new Error('Test error');
     const startTime = Date.now();
-    executor.events.emitStepError(testStep as any, testError, startTime);
+    executor.events.emitStepError(testStep as any, testError, startTime, 'ce2');
 
     // Verify no error event was emitted (because step events are disabled)
     expect(errorEvents.length).toBe(0);
@@ -763,12 +763,13 @@ describe('FlowExecutor Events', () => {
     });
 
     // Directly emit events for each step type
-    executor.events.emitStepStart(loopStep as any, { context: {} } as any);
-    executor.events.emitStepStart(requestStep as any, { context: {} } as any);
-    executor.events.emitStepStart(conditionStep as any, { context: {} } as any);
-    executor.events.emitStepStart(transformStep as any, { context: {} } as any);
-    executor.events.emitStepStart(stopStep as any, { context: {} } as any);
-    executor.events.emitStepStart(unknownStep as any, { context: {} } as any);
+    const ctx: any = { context: {} };
+    executor.events.emitStepStart(loopStep as any, ctx, {}, 'corr1');
+    executor.events.emitStepStart(requestStep as any, ctx, {}, 'corr2');
+    executor.events.emitStepStart(conditionStep as any, ctx, {}, 'corr3');
+    executor.events.emitStepStart(transformStep as any, ctx, {}, 'corr4');
+    executor.events.emitStepStart(stopStep as any, ctx, {}, 'corr5');
+    executor.events.emitStepStart(unknownStep as any, ctx, {}, 'corr6');
 
     // Verify all step types were correctly identified
     expect(events.length).toBe(6);
@@ -867,7 +868,7 @@ describe('FlowExecutor Events', () => {
     });
 
     // Emit a step start event with extra context
-    executor.events.emitStepStart(testStep as any, executionContext, extraContext);
+    executor.events.emitStepStart(testStep as any, executionContext, extraContext, 'cid1');
 
     // Verify context merging happened correctly
     expect(events.length).toBe(1);
@@ -880,7 +881,7 @@ describe('FlowExecutor Events', () => {
     events.length = 0; // Clear events array
 
     // Emit another step start event
-    executor.events.emitStepStart(testStep as any, executionContext, extraContext);
+    executor.events.emitStepStart(testStep as any, executionContext, extraContext, 'cid2');
 
     // Verify context is not included
     expect(events.length).toBe(1);
@@ -919,7 +920,7 @@ describe('FlowExecutor Events', () => {
     const extraContext = { extraValue: 'extra' };
 
     // Test line 188: Context ternary in emitStepStart
-    events.emitStepStart(testStep as any, executionContext, extraContext);
+    events.emitStepStart(testStep as any, executionContext, extraContext, 'cid3');
 
     // Verify context was merged when includeContext is true
     expect(receivedEvents.length).toBe(1);
@@ -948,7 +949,7 @@ describe('FlowExecutor Events', () => {
     });
 
     // These should not emit anything now
-    events.emitStepStart(testStep as any, executionContext, extraContext);
+    events.emitStepStart(testStep as any, executionContext, extraContext, 'cid4');
     events.emitDependencyResolved(orderedSteps);
 
     expect(receivedEvents.length).toBe(0);
@@ -1015,8 +1016,8 @@ describe('FlowExecutor Events', () => {
 
     // Call emitStepSkip on both instances
     const skipReason = 'Condition evaluated to false';
-    eventsEnabled.emitStepSkip(testStep as any, skipReason);
-    eventsDisabled.emitStepSkip(testStep as any, skipReason); // This should hit line 261 with the early return
+    eventsEnabled.emitStepSkip(testStep as any, skipReason, 'cid5');
+    eventsDisabled.emitStepSkip(testStep as any, skipReason, 'cid6'); // This should hit line 261 with the early return
 
     // Verify events were emitted correctly
     expect(enabledEvents.length).toBe(1);

--- a/src/types.ts
+++ b/src/types.ts
@@ -129,6 +129,10 @@ export interface Step {
   stop?: {
     endWorkflow?: boolean;
   };
+  /**
+   * Optional custom metadata for this step
+   */
+  metadata?: Record<string, any>;
   timeout?: number;
 }
 

--- a/src/util/flow-executor-events.ts
+++ b/src/util/flow-executor-events.ts
@@ -62,6 +62,8 @@ export interface StepStartEvent extends FlowEvent {
   stepName: string;
   stepType: StepType;
   context?: Record<string, any>;
+  correlationId: string;
+  metadata?: Record<string, any>;
 }
 
 /**
@@ -73,6 +75,7 @@ export interface StepCompleteEvent extends FlowEvent {
   stepType: StepType;
   result: StepExecutionResult;
   duration: number;
+  correlationId: string;
 }
 
 /**
@@ -84,6 +87,7 @@ export interface StepErrorEvent extends FlowEvent {
   stepType: StepType;
   error: Error;
   duration: number;
+  correlationId: string;
 }
 
 /**
@@ -93,6 +97,7 @@ export interface StepSkipEvent extends FlowEvent {
   type: FlowEventType.STEP_SKIP;
   stepName: string;
   reason: string;
+  correlationId: string;
 }
 
 /**
@@ -204,6 +209,8 @@ export class FlowExecutorEvents extends EventEmitter {
     step: Step,
     executionContext: StepExecutionContext,
     extraContext: Record<string, any> = {},
+    correlationId: string,
+    metadata: Record<string, any> = {},
   ): void {
     if (!this.options.emitStepEvents) return;
 
@@ -219,13 +226,20 @@ export class FlowExecutorEvents extends EventEmitter {
       stepName: step.name,
       stepType,
       context,
+      correlationId,
+      metadata,
     } as StepStartEvent);
   }
 
   /**
    * Emit step complete event
    */
-  emitStepComplete(step: Step, result: StepExecutionResult, startTime: number): void {
+  emitStepComplete(
+    step: Step,
+    result: StepExecutionResult,
+    startTime: number,
+    correlationId: string,
+  ): void {
     if (!this.options.emitStepEvents) return;
 
     const stepType = getStepType(step);
@@ -238,13 +252,14 @@ export class FlowExecutorEvents extends EventEmitter {
       stepType,
       result: resultData,
       duration: Date.now() - startTime,
+      correlationId,
     } as StepCompleteEvent);
   }
 
   /**
    * Emit step error event
    */
-  emitStepError(step: Step, error: Error, startTime: number): void {
+  emitStepError(step: Step, error: Error, startTime: number, correlationId: string): void {
     if (!this.options.emitStepEvents) return;
 
     const stepType = getStepType(step);
@@ -256,13 +271,14 @@ export class FlowExecutorEvents extends EventEmitter {
       stepType,
       error,
       duration: Date.now() - startTime,
+      correlationId,
     } as StepErrorEvent);
   }
 
   /**
    * Emit step skip event
    */
-  emitStepSkip(step: Step, reason: string): void {
+  emitStepSkip(step: Step, reason: string, correlationId: string): void {
     if (!this.options.emitStepEvents) return;
 
     this.emit(FlowEventType.STEP_SKIP, {
@@ -270,6 +286,7 @@ export class FlowExecutorEvents extends EventEmitter {
       type: FlowEventType.STEP_SKIP,
       stepName: step.name,
       reason,
+      correlationId,
     } as StepSkipEvent);
   }
 


### PR DESCRIPTION
## Summary
- include per-step metadata and a correlationId in step events
- support correlation metadata in FlowExecutor
- test abort behavior and correlationId output
- update coverage thresholds

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68474353e7f8832faa71e455274bbe7f