### PR TITLE
feat: add optional openrpc method definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,27 @@ Execute JSON-RPC requests with error handling:
 }
 ```
 
+### OpenRPC Method Definitions
+
+Steps can optionally include an `openrpc` field describing the inputs and output of the step using the OpenRPC method object. This makes the expected parameters and result explicit:
+
+```typescript
+{
+  name: 'getUser',
+  openrpc: {
+    name: 'getUser',
+    params: [
+      { name: 'id', required: true, schema: { type: 'number' } }
+    ],
+    result: { name: 'user', schema: { type: 'object' } }
+  },
+  request: {
+    method: 'user.get',
+    params: { id: 1 }
+  }
+}
+```
+
 ### Transform Steps
 
 Transform data using operations like map, filter, reduce:

--- a/meta-schema.json
+++ b/meta-schema.json
@@ -51,6 +51,10 @@
         },
         "policies": {
           "$ref": "#/definitions/Policies"
+        },
+        "openrpc": {
+          "$ref": "#/definitions/OpenRPCMethod",
+          "description": "Optional OpenRPC method definition describing the step's interface"
         }
       },
       "oneOf": [
@@ -324,6 +328,29 @@
             }
           }
         }
+      }
+    },
+    "OpenRPCContentDescriptor": {
+      "type": "object",
+      "required": ["name", "schema"],
+      "properties": {
+        "name": { "type": "string" },
+        "description": { "type": "string" },
+        "required": { "type": "boolean" },
+        "schema": { "type": "object" }
+      }
+    },
+    "OpenRPCMethod": {
+      "type": "object",
+      "required": ["name", "params", "result"],
+      "properties": {
+        "name": { "type": "string" },
+        "description": { "type": "string" },
+        "params": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/OpenRPCContentDescriptor" }
+        },
+        "result": { "$ref": "#/definitions/OpenRPCContentDescriptor" }
       }
     }
   }

--- a/src/__tests__/step-executors/request-executor.test.ts
+++ b/src/__tests__/step-executors/request-executor.test.ts
@@ -56,6 +56,24 @@ describe('RequestStepExecutor', () => {
     });
   });
 
+  it('executes a request step with an OpenRPC method definition', async () => {
+    const step: RequestStep = {
+      name: 'getUser',
+      openrpc: {
+        name: 'getUser',
+        params: [{ name: 'id', required: true, schema: { type: 'number' } }],
+        result: { name: 'user', schema: { type: 'object' } },
+      },
+      request: { method: 'user.get', params: { id: 2 } },
+    };
+
+    jsonRpcHandler.mockResolvedValue({ id: 2, name: 'User Two' });
+    const result = await executor.execute(step, context);
+
+    expect(result.type).toBe('request');
+    expect(result.result).toEqual({ id: 2, name: 'User Two' });
+  });
+
   it('resolves references in request parameters', async () => {
     const step: RequestStep = {
       name: 'getPermissions',

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,6 +87,26 @@ export interface FlowPolicies {
   };
 }
 
+/**
+ * Minimal OpenRPC content descriptor
+ */
+export interface OpenRPCContentDescriptor {
+  name: string;
+  description?: string;
+  required?: boolean;
+  schema: Record<string, any>;
+}
+
+/**
+ * Minimal OpenRPC method definition
+ */
+export interface OpenRPCMethod {
+  name: string;
+  description?: string;
+  params: OpenRPCContentDescriptor[];
+  result: OpenRPCContentDescriptor;
+}
+
 export interface Flow {
   name: string;
   description: string;
@@ -105,6 +125,10 @@ export interface Step {
    * Optional policies for this specific step
    */
   policies?: Policies;
+  /**
+   * Optional OpenRPC method definition describing the step's interface
+   */
+  openrpc?: OpenRPCMethod;
   request?: {
     method: string;
     params: Record<string, any> | any[];


### PR DESCRIPTION
## Summary
- support optional `openrpc` info on steps
- include schema for OpenRPC method definitions
- document how to use `openrpc` in a step
- test request executor with an OpenRPC method definition

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68474673683c832f97bb7eebe62fa53a