### PR TITLE
Add test for event emitter example

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,7 +14,7 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      branches: 92.61,
+      branches: 92.71,
       functions: 96.56,
       lines: 97.91,
       statements: 97.82,

--- a/src/__tests__/integration/event-emitter-example.test.ts
+++ b/src/__tests__/integration/event-emitter-example.test.ts
@@ -1,0 +1,26 @@
+import { FlowExecutor } from '../../flow-executor';
+import { flow as eventEmitterFlow } from '../../examples/event-emitter-example';
+import { FlowEventType } from '../../util/flow-executor-events';
+
+describe('Event Emitter Example', () => {
+  test('executes the example flow and emits events', async () => {
+    const handler = jest.fn().mockImplementation((req) => {
+      if (req.method === 'echoMany') {
+        return [{ data: req.params.message }];
+      }
+      if (req.method === 'echo') {
+        return { data: req.params.message };
+      }
+      throw new Error(`Unknown method: ${req.method}`);
+    });
+
+    const executor = new FlowExecutor(eventEmitterFlow, handler);
+    const emitted: FlowEventType[] = [];
+    executor.events.on(FlowEventType.STEP_COMPLETE, (evt) => emitted.push(evt.type));
+
+    const results = await executor.execute();
+
+    expect(results.get('step3').result).toEqual([{ data: 'Hello! World!' }]);
+    expect(emitted).toContain(FlowEventType.STEP_COMPLETE);
+  });
+});

--- a/src/examples/event-emitter-example.ts
+++ b/src/examples/event-emitter-example.ts
@@ -13,7 +13,7 @@ const flow: Flow = {
     {
       name: 'step1',
       request: {
-        method: 'echo',
+        method: 'echoMany',
         params: { message: 'Hello!' },
       },
     },
@@ -31,7 +31,7 @@ const flow: Flow = {
         operations: [
           {
             type: 'map',
-            using: 'item => ({ ...item, data: item.data + " " + ${step2.result.data} })',
+            using: '{...${item}, data: ${item.data} + " " + ${step2.result.data}}',
           },
         ],
       },
@@ -44,8 +44,11 @@ const jsonRpcHandler = async (request: JsonRpcRequest) => {
   // Simulate network delay
   await new Promise((resolve) => setTimeout(resolve, 500));
 
+  if (request.method === 'echoMany') {
+    const params = request.params as Record<string, any>;
+    return [{ data: params.message }];
+  }
   if (request.method === 'echo') {
-    // Safely access the message property with type checking
     const params = request.params as Record<string, any>;
     return { data: params.message };
   }


### PR DESCRIPTION
## Summary
- update coverage thresholds after tests
- fix the event emitter example
- add integration test for the event emitter example

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68474612a2d4832fb5ba73e8d54051d3