### PR TITLE
feat: add input type debug logs

### DIFF
--- a/src/step-executors/condition-executor.ts
+++ b/src/step-executors/condition-executor.ts
@@ -1,6 +1,7 @@
 import { Step, StepExecutionContext } from '../types';
 import { StepExecutor, StepExecutionResult, StepType, ConditionStep } from './types';
 import { Logger } from '../util/logger';
+import { getDataType } from '../util/type-utils';
 import { ValidationError, ExecutionError } from '../errors/base';
 import { TimeoutError } from '../errors/timeout-error';
 
@@ -71,6 +72,12 @@ export class ConditionStepExecutor implements StepExecutor {
           extraContext,
           step,
         );
+
+        this.logger.debug('Condition input type', {
+          stepName: step.name,
+          expected: 'boolean',
+          actual: getDataType(conditionValue),
+        });
 
         this.logger.debug('Condition evaluated', {
           stepName: step.name,

--- a/src/step-executors/loop-executor.ts
+++ b/src/step-executors/loop-executor.ts
@@ -2,6 +2,7 @@ import { Step, StepExecutionContext } from '../types';
 import { StepExecutor, StepExecutionResult, StepType, LoopStep } from './types';
 import { Logger } from '../util/logger';
 import { ValidationError, LoopStepExecutionError } from '../errors/base';
+import { getDataType } from '../util/type-utils';
 
 export type ExecuteStep = (
   step: Step,
@@ -50,6 +51,12 @@ export class LoopStepExecutor implements StepExecutor {
     try {
       // Resolve the collection to iterate over using expressionEvaluator
       const collection = context.expressionEvaluator.evaluate(loopStep.loop.over, extraContext);
+
+      this.logger.debug('Loop collection type check', {
+        stepName: step.name,
+        expected: 'array',
+        actual: getDataType(collection),
+      });
 
       if (!Array.isArray(collection)) {
         throw new ValidationError(`Loop "over" value must resolve to an array`, {

--- a/src/step-executors/request-executor.ts
+++ b/src/step-executors/request-executor.ts
@@ -1,6 +1,7 @@
 import { Step, StepExecutionContext, JsonRpcHandler } from '../types';
 import { StepExecutor, StepExecutionResult, JsonRpcRequestError, StepType } from './types';
 import { Logger } from '../util/logger';
+import { getDataType } from '../util/type-utils';
 import { RequestStep } from './types';
 import { RetryPolicy, RetryableOperation } from '../errors/recovery';
 import { ExecutionError, ValidationError } from '../errors/base';
@@ -72,6 +73,15 @@ export class RequestStepExecutor implements StepExecutor {
     const requestId = this.getNextRequestId();
     const stepRetryPolicy = this.getStepRetryPolicy(requestStep, _context);
     const timeout = this.getStepTimeout(requestStep, _context);
+
+    this.logger.debug('Checking request input types', {
+      stepName: step.name,
+      expected: { method: 'string', params: 'object | array | null' },
+      actual: {
+        method: typeof requestStep.request.method,
+        params: getDataType(requestStep.request.params),
+      },
+    });
 
     this.logger.debug('Executing request step', {
       stepName: step.name,

--- a/src/step-executors/stop-executor.ts
+++ b/src/step-executors/stop-executor.ts
@@ -1,6 +1,7 @@
 import { Step } from '../types';
 import { StepExecutor, StepExecutionResult, StepType } from './types';
 import { Logger } from '../util/logger';
+import { getDataType } from '../util/type-utils';
 import { ValidationError } from '../errors/base';
 
 export interface StopStep extends Step {
@@ -35,6 +36,12 @@ export class StopStepExecutor implements StepExecutor {
 
     const stopStep = step as StopStep;
     const endWorkflow = stopStep.stop.endWorkflow ?? false;
+
+    this.logger.debug('Stop step input type', {
+      stepName: step.name,
+      expected: 'boolean',
+      actual: getDataType(stopStep.stop.endWorkflow),
+    });
 
     this.logger.debug('Executing stop step', {
       stepName: step.name,

--- a/src/step-executors/transform-executor.ts
+++ b/src/step-executors/transform-executor.ts
@@ -7,6 +7,7 @@ import {
   TransformOperation,
 } from './types';
 import { Logger } from '../util/logger';
+import { getDataType } from '../util/type-utils';
 import { SafeExpressionEvaluator } from '../expression-evaluator/safe-evaluator';
 import { ReferenceResolver } from '../reference-resolver';
 import { TimeoutError } from '../errors/timeout-error';
@@ -452,8 +453,8 @@ export class TransformStepExecutor implements StepExecutor {
 
       this.logger.debug('Resolved transform input', {
         stepName: step.name,
-        inputType: typeof resolvedInput,
-        isArray: Array.isArray(resolvedInput),
+        expected: 'string | array',
+        actual: getDataType(resolvedInput),
       });
 
       const result = await this.transformExecutor.execute(

--- a/src/util/__tests__/type-utils.test.ts
+++ b/src/util/__tests__/type-utils.test.ts
@@ -1,0 +1,17 @@
+import { getDataType } from '../type-utils';
+
+describe('getDataType', () => {
+  it('returns array for arrays', () => {
+    expect(getDataType([1, 2])).toBe('array');
+  });
+
+  it('returns null for null values', () => {
+    expect(getDataType(null)).toBe('null');
+  });
+
+  it('returns typeof value for others', () => {
+    expect(getDataType('foo')).toBe('string');
+    expect(getDataType(123)).toBe('number');
+    expect(getDataType({})).toBe('object');
+  });
+});

--- a/src/util/type-utils.ts
+++ b/src/util/type-utils.ts
@@ -1,0 +1,5 @@
+export function getDataType(value: unknown): string {
+  if (Array.isArray(value)) return 'array';
+  if (value === null) return 'null';
+  return typeof value;
+}


### PR DESCRIPTION
## Summary
- log expected vs actual input types for each step
- provide a helper for obtaining data type
- test getDataType helper

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Integration: Transform Step Timeout (real timers))*

------
https://chatgpt.com/codex/tasks/task_e_684748618b54832fbf89f505f952380e