### PR TITLE
feat: allow resuming flows

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,10 +14,10 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      branches: 92.65,
-      functions: 96.56,
-      lines: 97.91,
-      statements: 97.82,
+      branches: 92.79,
+      functions: 96.58,
+      lines: 98.12,
+      statements: 98.02,
     },
   },
 };

--- a/src/__tests__/resume-workflow.test.ts
+++ b/src/__tests__/resume-workflow.test.ts
@@ -1,0 +1,56 @@
+import { FlowExecutor } from '../flow-executor';
+import { Flow } from '../types';
+import { FlowEventType } from '../util/flow-executor-events';
+import { TestLogger } from '../util/logger';
+import { StepType } from '../step-executors/types';
+
+describe('FlowExecutor resume capability', () => {
+  it('skips already executed steps', async () => {
+    const flow: Flow = {
+      name: 'ResumeFlow',
+      description: 'resume',
+      steps: [
+        { name: 's1', request: { method: 'a', params: {} } },
+        { name: 's2', request: { method: 'b', params: {} } },
+      ],
+    };
+
+    const handler = jest.fn().mockResolvedValue({ ok: true });
+
+    const previous = new Map<string, any>();
+    previous.set('s1', { type: StepType.Request, result: { ok: true }, metadata: {} });
+
+    const executor = new FlowExecutor(flow, handler, new TestLogger('resume'), previous);
+
+    const skips: any[] = [];
+    executor.events.on(FlowEventType.STEP_SKIP, (e) => skips.push(e));
+
+    const results = await executor.execute();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(skips.some((e) => e.stepName === 's1')).toBe(true);
+    expect(results.get('s1').result).toEqual({ ok: true });
+  });
+
+  it('merges provided context', async () => {
+    const flow: Flow = {
+      name: 'CtxFlow',
+      description: 'ctx',
+      context: { foo: 'bar' },
+      steps: [{ name: 's1', request: { method: 'a', params: { val: '${context.foo}' } } }],
+    };
+
+    const handler = jest.fn().mockResolvedValue({ ok: true });
+
+    const executor = new FlowExecutor(flow, handler, new TestLogger('ctx'), undefined, {
+      foo: 'baz',
+    });
+
+    await executor.execute();
+
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({ params: { val: 'baz' } }),
+      expect.anything(),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- extend `FlowExecutor` constructor to accept initial step results and context
- skip execution of steps whose results already exist
- add tests for resume and context merge
- update coverage thresholds

## Testing
- `npm run lint`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854b2e8b6148329a1904e36d85a474d